### PR TITLE
Update bmp581.py correct altitude calc, and remove excessive rounding…

### DIFF
--- a/bmp581.py
+++ b/bmp581.py
@@ -278,11 +278,11 @@ class BMP581:
         With the measured pressure p and the absolute altitude the pressure at sea level
         can be calculated too. See the altitude setter for this calculation
         """
-
+        # updated to Bosch’s formula in bmp180 datasheet, and eliminate excessive rounding of altitude
         altitude = 44330.0 * (
-            1.0 - ((self.pressure / self.sea_level_pressure) ** 0.190284)
+            1.0 - ((self.pressure / self.sea_level_pressure) ** (1.0 / 5.255))
         )
-        return round(altitude, 1)
+        return altitude
 
     @altitude.setter
     def altitude(self, value: float) -> None:


### PR DESCRIPTION
… of alt

In the Bosch Sensor guide (ex: in bmp180 they show a different formula page 16 of: https://cdn-shop.adafruit.com/datasheets/BST-BMP180-DS000-09.pdf).  Since you are raising the difference  in pressure & SLP to a power small differences can make a difference.